### PR TITLE
configure jest 29 to import node/cjs instead of browser builds, see h…

### DIFF
--- a/__tests__/unit/data-reformat-test.ts
+++ b/__tests__/unit/data-reformat-test.ts
@@ -1,11 +1,9 @@
-import { getDataModelIssues } from '../../src/contacsPane'
-
-comsole.log('data reformat test')
+import {parse} from "rdflib";
+import {store} from "solid-logic";
+import {ns} from "solid-ui";
 
 import pane from "../../contactsPane";
-import { parse } from "rdflib";
-import { store } from "solid-logic";
-import { context, doc, subject } from "./setup";
+import {context, doc, subject} from "./setup";
 
 // This was at testingsolidos.solidcommunity.net
 const exampleProfile = `@prefix : <#>.

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,4 +2,8 @@ module.exports = {
   testEnvironment: 'jsdom',
   setupFilesAfterEnv: ["./jest.setup.ts"],
   transformIgnorePatterns: ["/node_modules/(?!lit-html).+\\.js"],
+  testEnvironmentOptions: {
+    customExportConditions: ['node']
+  },
+  testPathIgnorePatterns: ["setup.ts"]
 };

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,4 +1,5 @@
-// import "@testing-library/jest-dom";
-// import fetchMock from "jest-fetch-mock";
+// Polyfill for encoding which isn't present globally in jsdom
+import { TextEncoder, TextDecoder } from 'util';
 
-// fetchMock.enableMocks();
+global.TextEncoder = TextEncoder;
+global.TextDecoder = TextDecoder;


### PR DESCRIPTION
https://jestjs.io/docs/28.x/upgrading-to-jest28#packagejson-exports