### PR TITLE
fix(test,dev): support uvdsl auth compatibility in dev and jest

### DIFF
--- a/dev/index.ts
+++ b/dev/index.ts
@@ -14,9 +14,10 @@ loginBanner.appendChild(UI.login.loginStatusBox(document, null, {}))
 const webIdToShow = 'https://testingsolidos.solidcommunity.net/profile/card#me'
 
 async function finishLogin() {
-  await authSession.handleIncomingRedirect({ restorePreviousSession: true })
+  await authn.checkUser()
   const session = authSession
-  if (session.info.isLoggedIn) {
+  const isLoggedIn = session?.info?.isLoggedIn ?? session?.isActive ?? Boolean(session?.webId)
+  if (isLoggedIn) {
     // Update the page with the status.
     webId.textContent = 'Logged in as: ' + authn.currentUser().uri
   } else {

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -12,12 +12,16 @@ export default {
   // Some npm packages publish ESM sources. By default Jest will NOT transform
   // files in node_modules which causes syntax errors like "import ..." here.
   // Allow transforming mime-types and mime-db so Babel can compile them for tests.
-  transformIgnorePatterns: ['/node_modules/(?!(mime-types|mime-db)/)'],
+  transformIgnorePatterns: ['/node_modules/(?!(mime-types|mime-db|uuid|@noble/curves|@noble/hashes)/)'],
   setupFilesAfterEnv: ['./test/jest.setup.ts'],
   testMatch: ['**/test/**/*.test.ts?(x)', '**/?(*.)+(spec|test).ts?(x)'],
   roots: ['<rootDir>/src', '<rootDir>/test'],
   moduleNameMapper: {
-    '^SolidLogic$': 'solid-logic',
+    '^solid-ui$': '<rootDir>/../solid-ui/src/index.ts',
+    '^solid-logic$': '<rootDir>/../solid-logic/src/index.ts',
+    '^SolidLogic$': '<rootDir>/../solid-logic/src/index.ts',
+    '^@uvdsl/solid-oidc-client-browser$': '<rootDir>/test/__mocks__/solid-oidc-client-browser.ts',
+    '^@uvdsl/solid-oidc-client-browser/core$': '<rootDir>/test/__mocks__/solid-oidc-client-browser.ts',
     '^\\$rdf$': 'rdflib',
     '\\.css$': '<rootDir>/test/__mocks__/styleMock.js'
   },

--- a/test/__mocks__/solid-oidc-client-browser.ts
+++ b/test/__mocks__/solid-oidc-client-browser.ts
@@ -1,0 +1,85 @@
+type Listener = (...args: any[]) => void
+
+class EventEmitterLike {
+  private listeners: Record<string, Listener[]> = {}
+
+  on (event: string, listener: Listener): void {
+    const list = this.listeners[event] || []
+    list.push(listener)
+    this.listeners[event] = list
+  }
+
+  emit (event: string, ...args: any[]): void {
+    const list = this.listeners[event] || []
+    list.forEach(listener => listener(...args))
+  }
+}
+
+export class Session {
+  info: { webId?: string, isLoggedIn: boolean } = { isLoggedIn: false }
+  webId?: string
+  isActive = false
+  events = new EventEmitterLike()
+
+  async handleIncomingRedirect (): Promise<void> {
+
+  }
+
+  async handleRedirectFromLogin (): Promise<void> {
+
+  }
+
+  async restore (): Promise<void> {
+
+  }
+
+  async login (): Promise<void> {
+
+  }
+
+  async logout (): Promise<void> {
+    this.info = { isLoggedIn: false }
+    this.webId = undefined
+    this.isActive = false
+  }
+
+  fetch (input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+    return globalThis.fetch(input, init)
+  }
+
+  authFetch (input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+    return globalThis.fetch(input, init)
+  }
+}
+
+export class SessionCore extends Session {
+  constructor (_clientDetails?: unknown, _sessionOptions?: unknown) {
+    super()
+  }
+}
+
+export class SessionIDB {
+  async init (): Promise<SessionIDB> {
+    return this
+  }
+
+  async setItem (_id: string, _value: any): Promise<void> {
+
+  }
+
+  async getItem (_id: string): Promise<any> {
+    return null
+  }
+
+  async deleteItem (_id: string): Promise<void> {
+
+  }
+
+  async clear (): Promise<void> {
+
+  }
+
+  close (): void {
+
+  }
+}


### PR DESCRIPTION
Use authn.checkUser and compatibility-safe session checks in the dev entrypoint.\nMap uvdsl OIDC modules to a local Jest mock and allow transforming required ESM dependencies in tests.