### PR TITLE
fix(build): work around Rolldown preserveModules CJS interop bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "contacts-pane",
-  "version": "3.2.1-3",
+  "version": "3.2.1-4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "contacts-pane",
-      "version": "3.2.1-3",
+      "version": "3.2.1-4",
       "license": "MIT",
       "dependencies": {
         "@lit/context": "^1.1.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,13 +22,14 @@
         "globals": "^17.1.0",
         "jsdom": "^28.1.0",
         "neostandard": "^0.13.0",
-        "pane-registry": "^3.0.1",
-        "rdflib": "^2.3.6",
-        "solid-logic": "^4.0.6",
-        "solid-ui": "dev",
-        "solidos-toolkit": "dev",
+        "pane-registry": "^3.1.2-0",
+        "rdflib": "^2.4.0",
+        "solid-logic": "^4.0.8-0",
+        "solid-ui": "^3.1.3-6",
+        "solidos-toolkit": "0.0.0-dev.4732b482981fe79667863101428a9c7249083a67",
         "typescript": "^6.0.2",
         "vite": "^8.0.16",
+        "vite-plugin-css-injected-by-js": "^5.0.1",
         "vitest": "^4.0.18",
         "vitest-axe": "^0.1.0"
       }
@@ -176,6 +177,19 @@
         "url": "https://opencollective.com/babel"
       }
     },
+    "node_modules/@babel/core/node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@babel/core/node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -252,6 +266,13 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
       "version": "7.29.7",
@@ -2476,48 +2497,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
-      }
-    },
-    "node_modules/@inrupt/oidc-client-ext": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/oidc-client-ext/-/oidc-client-ext-4.0.0.tgz",
-      "integrity": "sha512-E32/yElFpADyWRFO6FdCyB1Ew1svsNX/fFdvHWP3qCBhSlfJVq2hMChWxs/RIRmTjHePyjT2UKEuItM09WXaWA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@inrupt/solid-client-authn-core": "^4.0.0",
-        "jose": "^5.1.3",
-        "oidc-client-ts": "^3.5.0",
-        "uuid": "^11.1.0"
-      }
-    },
-    "node_modules/@inrupt/solid-client-authn-browser": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-browser/-/solid-client-authn-browser-4.0.0.tgz",
-      "integrity": "sha512-b7DpLMjYVMPiRv3QWqOmCeYqKL1t2THYQawuYM1zNqtN1SJGG5XEkXIy3ZQxx12tzAjeLNjH3ZAOg/CK/ehg2w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@inrupt/oidc-client-ext": "^4.0.0",
-        "@inrupt/solid-client-authn-core": "^4.0.0",
-        "events": "^3.3.0",
-        "jose": "^5.1.3",
-        "uuid": "^11.1.0"
-      }
-    },
-    "node_modules/@inrupt/solid-client-authn-core": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-4.0.0.tgz",
-      "integrity": "sha512-q4iur4TxEkhk9XaGAvyRP/+MjU1oBv2xlBdGE+uoXmDHAnIqUN71zZjCWZfZlyQFRETgH3OfZ9tPrNSDIPA/wg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "events": "^3.3.0",
-        "jose": "^5.1.3",
-        "uuid": "^11.1.0"
-      },
-      "engines": {
-        "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -4749,9 +4728,9 @@
       "license": "ISC"
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.24.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.0.tgz",
-      "integrity": "sha512-SkE2t82KlkkxQRVMVLAGKxLfORGQfrkx5dkj+vlgXRVNEdPc4eZcR+J/Fvj8C+yKSFH5L0q3NFlyufOVQnCcYQ==",
+      "version": "5.24.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.1.tgz",
+      "integrity": "sha512-7DdUaTjmNwMcH2gLr1qycesKII3BK4RLy/mdAb7x10Lq7bR4aNKHt1BR1ZALSv0rPM/hF5wYF0PhGop/rJm8vw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5589,9 +5568,9 @@
       }
     },
     "node_modules/expect-type": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
-      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -7009,16 +6988,16 @@
       "license": "MIT"
     },
     "node_modules/json5": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
       "bin": {
         "json5": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/jsonld": {
@@ -7050,13 +7029,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/jsonld/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -7071,16 +7043,6 @@
       },
       "engines": {
         "node": ">=4.0"
-      }
-    },
-    "node_modules/jwt-decode": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
-      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/keyv": {
@@ -7709,9 +7671,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "5.1.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.15.tgz",
-      "integrity": "sha512-kBg3RpGtIe+RpTbyXwoI6pk5yD7KUiI3sygUqgeBMRst42KmhB4RZC7eiO9Wa1HIpaCCtpE2DJ6OI4Wi5ebwFw==",
+      "version": "5.1.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.16.tgz",
+      "integrity": "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==",
       "dev": true,
       "funding": [
         {
@@ -7936,9 +7898,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.49",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.49.tgz",
-      "integrity": "sha512-f06bl1D+8ZDkn2oOQQKAh5/otFWqVnM1Q5oerA8Pex7UfT66Tx4IPHIqVVFKqFT3FUtaDstdgkM7yT7JWhqxfw==",
+      "version": "2.0.50",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
+      "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8165,19 +8127,6 @@
         "node": ">=12.20.0"
       }
     },
-    "node_modules/oidc-client-ts": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/oidc-client-ts/-/oidc-client-ts-3.5.0.tgz",
-      "integrity": "sha512-l2q8l9CTCTOlbX+AnK4p3M+4CEpKpyQhle6blQkdFhm0IsBqsxm15bYaSa11G7pWdsYr6epdsRZxJpCyCRbT8A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "jwt-decode": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/one-by-one": {
       "version": "3.2.9",
       "resolved": "https://registry.npmjs.org/one-by-one/-/one-by-one-3.2.9.tgz",
@@ -8323,14 +8272,14 @@
       }
     },
     "node_modules/pane-registry": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/pane-registry/-/pane-registry-3.1.1.tgz",
-      "integrity": "sha512-aL1PdjIl+HMyC5NawVWKrqZ+q+Oz1PtgDvt7T04ArdUx+6lwrtqS1z+4DCy5LGRSeKamqIlHLClDIwkPpAEQlQ==",
+      "version": "3.1.2-0",
+      "resolved": "https://registry.npmjs.org/pane-registry/-/pane-registry-3.1.2-0.tgz",
+      "integrity": "sha512-oBFv4x+fNWAU9z+jZRtY2XIWT9DMhcr8ogSGSR5JIobq+tDYzw9VTAzrAz40JgBB7LGbmwz9ov1INcHSSQi6aQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "rdflib": "^2.3.7",
-        "solid-logic": "^4.0.7"
+        "rdflib": "2.3.9",
+        "solid-logic": "4.0.8-0"
       }
     },
     "node_modules/parent-module": {
@@ -8699,9 +8648,9 @@
       }
     },
     "node_modules/rdflib": {
-      "version": "2.3.9",
-      "resolved": "https://registry.npmjs.org/rdflib/-/rdflib-2.3.9.tgz",
-      "integrity": "sha512-6HnEQ22QzgqPW2/R8y5IaeQoXnho6U+ovU1q/ZF556zEnSK4buwhw8/CDdRDwIHZQh5+PAncQxUhluO3JmguJQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/rdflib/-/rdflib-2.4.0.tgz",
+      "integrity": "sha512-DPBFlnkA7lWgskbgyPsRxHE5S/9Ni5KHNgwzrq8CucG+TBxEHTGRSeMKjWhZlZhBhmQFu0YQGjOYyrzmkX/gwg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9296,20 +9245,20 @@
       "license": "MIT"
     },
     "node_modules/solid-logic": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/solid-logic/-/solid-logic-4.0.7.tgz",
-      "integrity": "sha512-qVHu6juUr+zg2swuc3dHLb/Zjb0aYLNvwpG3xWTqXe/iT3ZF9ORA6fs9UgQuMnsijSJcaoXjK/gB2hvpbm53fA==",
+      "version": "4.0.8-0",
+      "resolved": "https://registry.npmjs.org/solid-logic/-/solid-logic-4.0.8-0.tgz",
+      "integrity": "sha512-/vdP03m8zZPkh1nhpSWedlYR3pWDcLrGwFvwQc8wR3vIOYZ0MQME3vlcwW7T5yhrSRkKcrQD9Ubq06tDRUBIrQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inrupt/solid-client-authn-browser": "^4.0.0",
+        "@uvdsl/solid-oidc-client-browser": "^0.2.3",
         "solid-namespace": "^0.5.4"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "rdflib": "^2.3.7"
+        "rdflib": "^2.3.9"
       }
     },
     "node_modules/solid-namespace": {
@@ -9344,52 +9293,10 @@
         "fsevents": "*"
       }
     },
-    "node_modules/solid-ui/node_modules/pane-registry": {
-      "version": "3.1.2-0",
-      "resolved": "https://registry.npmjs.org/pane-registry/-/pane-registry-3.1.2-0.tgz",
-      "integrity": "sha512-oBFv4x+fNWAU9z+jZRtY2XIWT9DMhcr8ogSGSR5JIobq+tDYzw9VTAzrAz40JgBB7LGbmwz9ov1INcHSSQi6aQ==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "rdflib": "2.3.9",
-        "solid-logic": "4.0.8-0"
-      }
-    },
-    "node_modules/solid-ui/node_modules/solid-logic": {
-      "version": "4.0.8-0",
-      "resolved": "https://registry.npmjs.org/solid-logic/-/solid-logic-4.0.8-0.tgz",
-      "integrity": "sha512-/vdP03m8zZPkh1nhpSWedlYR3pWDcLrGwFvwQc8wR3vIOYZ0MQME3vlcwW7T5yhrSRkKcrQD9Ubq06tDRUBIrQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@uvdsl/solid-oidc-client-browser": "^0.2.3",
-        "solid-namespace": "^0.5.4"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "rdflib": "^2.3.9"
-      }
-    },
-    "node_modules/solid-ui/node_modules/uuid": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
-      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
-      }
-    },
     "node_modules/solidos-toolkit": {
-      "version": "0.0.0-dev.c1b3b5aa1d679049f956fda4b6d91b3790fd925f",
-      "resolved": "https://registry.npmjs.org/solidos-toolkit/-/solidos-toolkit-0.0.0-dev.c1b3b5aa1d679049f956fda4b6d91b3790fd925f.tgz",
-      "integrity": "sha512-6eCAy8CJywSeUpckNPBwEW8vrPPb7pO/k4CfkVhS8prax8/MuJ5id5ob1yWRrW+X0yEHRUtgoTJ5sGWdId1Mkw==",
+      "version": "0.0.0-dev.4732b482981fe79667863101428a9c7249083a67",
+      "resolved": "https://registry.npmjs.org/solidos-toolkit/-/solidos-toolkit-0.0.0-dev.4732b482981fe79667863101428a9c7249083a67.tgz",
+      "integrity": "sha512-o76tfijvwcHkT0p7rPJ5PO82sRSIoADjzE8q5pVmQlFUh7uceVneIGPUg5mLw2GCStpFl9hqf2DBg0jgIn9rUQ==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.29.0",
@@ -9406,10 +9313,10 @@
         "vite-plugin-lit-css": "^3.0.0"
       },
       "peerDependencies": {
-        "pane-registry": "^3.0.0",
-        "rdflib": "^2.3.0",
-        "solid-logic": "^4.0.0",
-        "solid-ui": "^3.1.2",
+        "pane-registry": "^3.1.1 || ^3.1.2-0",
+        "rdflib": "^2.3.6",
+        "solid-logic": "^4.0.7 || ^4.0.8-0",
+        "solid-ui": "^3.1.2 || ^3.1.3-0",
         "vite": "^8.0.0"
       },
       "peerDependenciesMeta": {
@@ -9428,6 +9335,16 @@
         "vite": {
           "optional": true
         }
+      }
+    },
+    "node_modules/solidos-toolkit/node_modules/vite-plugin-css-injected-by-js": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/vite-plugin-css-injected-by-js/-/vite-plugin-css-injected-by-js-3.5.2.tgz",
+      "integrity": "sha512-2MpU/Y+SCZyWUB6ua3HbJCrgnF0KACAsmzOQt1UvRVJCGF6S8xdA3ZUhWcWdM9ivG4I5az8PnQmwwrkC2CAQrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "vite": ">2.0.0-0"
       }
     },
     "node_modules/source-map-js": {
@@ -9865,19 +9782,6 @@
         "strip-bom": "^3.0.0"
       }
     },
-    "node_modules/tsconfig-paths/node_modules/json5": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.0"
-      },
-      "bin": {
-        "json5": "lib/cli.js"
-      }
-    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -10278,9 +10182,9 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
@@ -10288,7 +10192,7 @@
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/esm/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/validate-npm-package-license": {
@@ -10381,13 +10285,13 @@
       }
     },
     "node_modules/vite-plugin-css-injected-by-js": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/vite-plugin-css-injected-by-js/-/vite-plugin-css-injected-by-js-3.5.2.tgz",
-      "integrity": "sha512-2MpU/Y+SCZyWUB6ua3HbJCrgnF0KACAsmzOQt1UvRVJCGF6S8xdA3ZUhWcWdM9ivG4I5az8PnQmwwrkC2CAQrQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/vite-plugin-css-injected-by-js/-/vite-plugin-css-injected-by-js-5.0.1.tgz",
+      "integrity": "sha512-JSB0jjN4VCKqG7XTUdrwiIl5gA+z2yi/tAl9WHo0X4sdyJ1yrmbLOEjf95TDoDIIuKr4GJIc7lMJG0CT88eEUQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "vite": ">2.0.0-0"
+        "vite": ">8.0.0-0"
       }
     },
     "node_modules/vite-plugin-lit-css": {
@@ -10753,9 +10657,9 @@
       "license": "MIT"
     },
     "node_modules/yallist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true,
       "license": "ISC"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contacts-pane",
-  "version": "3.2.1-3",
+  "version": "3.2.1-4",
   "description": "Contacts Pane: Contacts manager for Address Book, Groups, and Individuals.",
   "main": "dist/index.cjs.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -68,17 +68,20 @@
     "globals": "^17.1.0",
     "jsdom": "^28.1.0",
     "neostandard": "^0.13.0",
-    "pane-registry": "^3.0.1",
-    "rdflib": "^2.3.6",
-    "solid-logic": "^4.0.6",
-    "solid-ui": "dev",
-    "solidos-toolkit": "dev",
+    "pane-registry": "^3.1.2-0",
+    "rdflib": "^2.4.0",
+    "solid-logic": "^4.0.8-0",
+    "solid-ui": "^3.1.3-6",
+    "solidos-toolkit": "0.0.0-dev.4732b482981fe79667863101428a9c7249083a67",
     "typescript": "^6.0.2",
     "vite": "^8.0.16",
+    "vite-plugin-css-injected-by-js": "^5.0.1",
     "vitest": "^4.0.18",
     "vitest-axe": "^0.1.0"
   },
   "overrides": {
+    "rdflib": "$rdflib",
+    "solid-logic": "$solid-logic",
     "solid-ui": "$solid-ui"
   }
 }

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -1,5 +1,6 @@
 import { solidPane, buildConfig } from "solidos-toolkit/vite";
 import { defineConfig } from "vitest/config";
+import { isAbsolute } from "node:path";
 
 export default defineConfig({
   plugins: solidPane({
@@ -8,10 +9,30 @@ export default defineConfig({
       subject: "https://solidos.solidcommunity.net/Contacts/index.ttl#this",
     },
   }),
-  resolve: {
-    tsconfigPaths: true,
-  },
-  build: buildConfig({ entry: "src/index.ts" }),
+
+  build: buildConfig({
+    entry: "src/index.ts",
+    overrides: {
+      rolldownOptions: {
+        output: [
+          {
+            format: "es",
+            preserveModules: true,
+            preserveModulesRoot: "src",
+            entryFileNames: "[name].esm.js",
+          },
+          {
+            format: "cjs",
+            preserveModules: false,
+            entryFileNames: "[name].cjs.js",
+          },
+        ],
+        external: (id: string) => {
+          return !id.startsWith(".") && !isAbsolute(id);
+        },
+      },
+    },
+  }),
   test: {
     environment: "jsdom",
     setupFiles: ["test/helpers/setup.ts"],


### PR DESCRIPTION
Pin solidos-toolkit to exact dev version (drop ^ to prevent resolution to 0.0.0 stub). Override CJS output to use a single bundle (preserveModules: false) while keeping ESM per-module. This avoids Rolldown producing invalid `const o=s=;;` code when converting named ESM imports to CJS requires.